### PR TITLE
fix: update author field, move files to `themes/`

### DIFF
--- a/fluentterminal.tera
+++ b/fluentterminal.tera
@@ -3,12 +3,12 @@ whiskers:
   version: "2.3.0"
   matrix:
    - flavor
-  filename: "Catppuccin-{{ flavor.name }}.flutecolors"
+  filename: "themes/catppuccin-{{ flavor.identifier }}.flutecolors"
 ---
 {
   "EncodedImage": "",
   "Name": "Catppuccin-{{ flavor.name }}",
-  "Author": "mrdoge515",
+  "Author": "Catppuccin",
   "Colors": {
     "Foreground": "#{{ text.hex }}",
     "Background": "#{{ base.hex }}",

--- a/themes/catppuccin-frappe.flutecolors
+++ b/themes/catppuccin-frappe.flutecolors
@@ -1,7 +1,7 @@
 {
   "EncodedImage": "",
   "Name": "Catppuccin-Frappé",
-  "Author": "mrdoge515",
+  "Author": "Catppuccin",
   "Colors": {
     "Foreground": "#c6d0f5",
     "Background": "#303446",

--- a/themes/catppuccin-latte.flutecolors
+++ b/themes/catppuccin-latte.flutecolors
@@ -1,7 +1,7 @@
 {
   "EncodedImage": "",
   "Name": "Catppuccin-Latte",
-  "Author": "mrdoge515",
+  "Author": "Catppuccin",
   "Colors": {
     "Foreground": "#4c4f69",
     "Background": "#eff1f5",

--- a/themes/catppuccin-macchiato.flutecolors
+++ b/themes/catppuccin-macchiato.flutecolors
@@ -1,7 +1,7 @@
 {
   "EncodedImage": "",
   "Name": "Catppuccin-Macchiato",
-  "Author": "mrdoge515",
+  "Author": "Catppuccin",
   "Colors": {
     "Foreground": "#cad3f5",
     "Background": "#24273a",

--- a/themes/catppuccin-mocha.flutecolors
+++ b/themes/catppuccin-mocha.flutecolors
@@ -1,7 +1,7 @@
 {
   "EncodedImage": "",
   "Name": "Catppuccin-Mocha",
-  "Author": "mrdoge515",
+  "Author": "Catppuccin",
   "Colors": {
     "Foreground": "#cdd6f4",
     "Background": "#1e1e2e",


### PR DESCRIPTION
As mentioned in #1, updates the author field as we do with other ports and moves the built theme files to the quasi-standard location of `themes/`.